### PR TITLE
Add Next.js mock job API routes

### DIFF
--- a/app/api/jobs/[id]/checklist/route.ts
+++ b/app/api/jobs/[id]/checklist/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest, context: { params: { id: string } }) {
+  const payload = await req.json();
+  console.log('Checklist submission for job', context.params.id, payload);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/jobs/[id]/route.ts
+++ b/app/api/jobs/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { jobs, Zone } from '../../../../lib/mockJobs';
+
+const checklistTemplates: Record<number, string[]> = {
+  1: ['Install Controller', 'Wire Relay', 'Attach Sensors'],
+  2: ['Install Controller', 'Check Existing Sensors'],
+  3: ['Software-only Verification']
+};
+
+export async function GET(req: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
+  const job = jobs.find(j => j.id === id);
+  if (!job) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const zonesWithChecklist = job.zones.map(zone => ({
+    ...zone,
+    checklist: checklistTemplates[zone.installMode]
+  }));
+
+  const result = {
+    ...job,
+    siteNotes: `Notes for job ${job.id}`,
+    zones: zonesWithChecklist
+  };
+
+  return NextResponse.json(result);
+}

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { jobs } from '../../../lib/mockJobs';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const installerId = searchParams.get('installerId');
+  const filtered = installerId
+    ? jobs.filter(job => job.installerId === installerId)
+    : jobs;
+  return NextResponse.json(filtered);
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { useJobs } from '../../lib/hooks';
+
+const statusColors: Record<string, string> = {
+  assigned: 'bg-blue-500',
+  in_progress: 'bg-yellow-500',
+  needs_qa: 'bg-orange-500',
+  complete: 'bg-green-500',
+  rework: 'bg-red-500',
+};
+
+export default function DashboardPage() {
+  const { jobs, isLoading, error } = useJobs();
+
+  if (isLoading) {
+    return <div>Loading…</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-600">{String(error)}</div>;
+  }
+
+  const statusCounts: Record<string, number> = {
+    assigned: 0,
+    in_progress: 0,
+    needs_qa: 0,
+    complete: 0,
+    rework: 0,
+  };
+
+  jobs?.forEach(job => {
+    statusCounts[job.status]++;
+  });
+
+  const todaysInstalls = jobs?.filter(
+    job => job.status === 'assigned' || job.status === 'in_progress'
+  ) || [];
+
+  const attentionRequired = jobs?.filter(
+    job => job.status === 'needs_qa' || job.status === 'rework'
+  ) || [];
+
+  return (
+    <div className="space-y-8 p-4">
+      {/* Status Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {Object.entries(statusCounts).map(([status, count]) => (
+          <div
+            key={status}
+            className={`${statusColors[status]} text-white rounded-md p-4 flex flex-col items-center justify-center`}
+          >
+            <div className="text-2xl font-bold">{count}</div>
+            <div className="capitalize">{status.replace('_', ' ')}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Today’s Installs Table */}
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Today’s Installs</h2>
+        <table className="min-w-full border border-gray-200">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-2 py-1 text-left">Installer</th>
+              <th className="px-2 py-1 text-left">Address</th>
+              <th className="px-2 py-1 text-left">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {todaysInstalls.map(job => (
+              <tr key={job.id} className="border-t">
+                <td className="px-2 py-1">{job.installerId}</td>
+                <td className="px-2 py-1">{job.address}</td>
+                <td className="px-2 py-1 capitalize">{job.status.replace('_', ' ')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Attention Required Section */}
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Attention Required</h2>
+        <ul className="list-disc ml-5 space-y-1">
+          {attentionRequired.map(job => (
+            <li key={job.id}>
+              Job #{job.id} — {job.status === 'needs_qa' ? 'Needs QA' : 'Rework'}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import type { Job, Zone } from './mockJobs';
+
+export interface ZoneWithChecklist extends Zone {
+  checklist: string[];
+}
+
+export interface JobDetail extends Job {
+  siteNotes: string;
+  zones: ZoneWithChecklist[];
+}
+
+export function useJobs(installerId?: string) {
+  const [jobs, setJobs] = useState<Job[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    const url = installerId
+      ? `/api/jobs?installerId=${encodeURIComponent(installerId)}`
+      : '/api/jobs';
+    setIsLoading(true);
+    setError(null);
+    fetch(url)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        return res.json();
+      })
+      .then(data => setJobs(data))
+      .catch(err => setError(err))
+      .finally(() => setIsLoading(false));
+  }, [installerId]);
+
+  return { jobs, isLoading, error };
+}
+
+export function useJob(jobId: string) {
+  const [job, setJob] = useState<JobDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const url = `/api/jobs/${jobId}`;
+    setIsLoading(true);
+    setError(null);
+    fetch(url)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        return res.json();
+      })
+      .then(data => setJob(data))
+      .catch(err => setError(err))
+      .finally(() => setIsLoading(false));
+  }, [jobId]);
+
+  return { job, isLoading, error };
+}
+
+export function useSubmitChecklist() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  async function submitChecklist(payload: any) {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/jobs/${payload.jobId}/checklist`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      const data = await res.json();
+      console.log('Checklist submitted:', data);
+    } catch (err) {
+      console.error('Checklist submission failed:', err);
+      setError(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return { submitChecklist, isSubmitting, error };
+}
+
+export default { useJobs, useJob, useSubmitChecklist };

--- a/lib/mockJobs.ts
+++ b/lib/mockJobs.ts
@@ -1,0 +1,56 @@
+export type Status = 'assigned' | 'in_progress' | 'needs_qa' | 'complete' | 'rework';
+
+export interface Zone {
+  zoneName: string;
+  installMode: 1 | 2 | 3;
+  quoteLineItems: string[];
+  notes: string;
+}
+
+export interface Job {
+  id: string;
+  customerName: string;
+  address: string;
+  status: Status;
+  installerId: string;
+  zones: Zone[];
+}
+
+export const jobs: Job[] = [
+  {
+    id: 'job1',
+    customerName: 'Alice Smith',
+    address: '123 Main St, Springfield',
+    status: 'assigned',
+    installerId: 'installer1',
+    zones: [
+      {
+        zoneName: 'Kitchen',
+        installMode: 1,
+        quoteLineItems: ['Controller', 'Relay'],
+        notes: 'Install near pantry'
+      },
+      {
+        zoneName: 'Living Room',
+        installMode: 2,
+        quoteLineItems: ['Sensors'],
+        notes: 'Existing sensors present'
+      }
+    ]
+  },
+  {
+    id: 'job2',
+    customerName: 'Bob Johnson',
+    address: '456 Oak Ave, Shelbyville',
+    status: 'in_progress',
+    installerId: 'installer2',
+    zones: [
+      {
+        zoneName: 'Main Entrance',
+        installMode: 3,
+        quoteLineItems: ['Software'],
+        notes: 'Remote configuration'
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- scaffold mock API routes for jobs in the Next.js App Router style
- define reusable mock job data

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f544c9b60832d8d3d3380835b1a94